### PR TITLE
Encoding was being replaced

### DIFF
--- a/Tokens/TokenizedStream.cs
+++ b/Tokens/TokenizedStream.cs
@@ -111,7 +111,7 @@ namespace SitefinityWebApp.Tokens
 
                 if (modified)
                 {
-                    buffer = Encoding.ASCII.GetBytes(output);
+                    buffer = encoding.GetBytes(output);
                 }
             }
 


### PR DESCRIPTION
Content encoding was being forced to switch to ASCII encoding instead of keeping the same encoding (i.e. UTF-8). This was causing issues with content where special characters like &copy; &cent; were being replaced by '?' character on all pages.